### PR TITLE
Update design in Transactions Screen #118

### DIFF
--- a/app/src/main/java/bitcoin/wallet/core/BitcoinAdapter.kt
+++ b/app/src/main/java/bitcoin/wallet/core/BitcoinAdapter.kt
@@ -180,7 +180,7 @@ class WalletKit(words: List<String>, network: NetworkParameters) {
             amount = 0.183
             fee = 0.00092
             blockHeight = 103
-            timestamp = 1536052151123
+            timestamp = 1490090153000
         }
         transactions.add(tr4)
 

--- a/app/src/main/java/bitcoin/wallet/modules/transactionInfo/TransactionInfoFragment.kt
+++ b/app/src/main/java/bitcoin/wallet/modules/transactionInfo/TransactionInfoFragment.kt
@@ -25,13 +25,14 @@ class TransactionInfoFragment : DialogFragment() {
 
     private lateinit var viewModel: TransactionInfoViewModel
 
-    private lateinit var transactionRecordViewItem: TransactionRecordViewItem
+    private var transactionRecordViewItem: TransactionRecordViewItem? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        viewModel = ViewModelProviders.of(this).get(TransactionInfoViewModel::class.java)
-        viewModel.init(transactionRecordViewItem)
+        transactionRecordViewItem?.let {
+            viewModel = ViewModelProviders.of(this).get(TransactionInfoViewModel::class.java)
+            viewModel.init(it)
+        } ?: kotlin.run { dismiss() }
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {

--- a/app/src/main/java/bitcoin/wallet/modules/transactions/TransactionsFragment.kt
+++ b/app/src/main/java/bitcoin/wallet/modules/transactions/TransactionsFragment.kt
@@ -17,7 +17,6 @@ import bitcoin.wallet.modules.transactionInfo.TransactionInfoModule
 import bitcoin.wallet.viewHelpers.DateHelper
 import bitcoin.wallet.viewHelpers.LayoutHelper
 import bitcoin.wallet.viewHelpers.NumberFormatHelper
-import bitcoin.wallet.viewHelpers.TextHelper
 import kotlinx.android.extensions.LayoutContainer
 import kotlinx.android.synthetic.main.fragment_transactions.*
 import kotlinx.android.synthetic.main.view_holder_filter.*
@@ -123,15 +122,16 @@ class ViewHolderTransaction(override val containerView: View) : RecyclerView.Vie
         val amountTextColor = if (transactionRecord.incoming) R.color.green_crypto else R.color.yellow_crypto
         txAmount.setTextColor(ContextCompat.getColor(itemView.context, amountTextColor))
         txAmount.text = "$sign ${NumberFormatHelper.cryptoAmountFormat.format(Math.abs(transactionRecord.amount.value))} ${transactionRecord.amount.coin.code}"
-        txDate.text = transactionRecord.date?.let { DateHelper.getRelativeDateString(itemView.context, it) }
-        val addressExcerpt = TextHelper.randomHashGenerator().take(6) + "\u2026"//todo replace after from starts to show address (transactionRecord.from)
-        txValueInFiat.text = "\$${NumberFormatHelper.fiatAmountFormat.format(transactionRecord.currencyAmount?.value)}" + " from " + addressExcerpt
+        txDate.text = transactionRecord.date?.let { DateHelper.getShortDateForTransaction(it) }
+        txTime.text = transactionRecord.date?.let { DateHelper.getOnlyTime(it) }
+        val absFiatValue = transactionRecord.currencyAmount?.value?.let { Math.abs(it) }
+        txValueInFiat.text = "~ \$ ${NumberFormatHelper.fiatAmountFormat.format(absFiatValue ?: 0)}"
         statusIcon.setImageDrawable(getStatusIcon(transactionRecord.status))
     }
 
     private fun getStatusIcon(status: TransactionRecordViewItem.Status?): Drawable? {
         return if (status == TransactionRecordViewItem.Status.SUCCESS)
-            LayoutHelper.getTintedDrawable(R.drawable.checkmark, R.color.grey, App.instance)
+            null
         else
             LayoutHelper.d(R.drawable.pending, App.instance)
     }

--- a/app/src/main/java/bitcoin/wallet/viewHelpers/DateHelper.kt
+++ b/app/src/main/java/bitcoin/wallet/viewHelpers/DateHelper.kt
@@ -8,7 +8,7 @@ import java.util.*
 
 object DateHelper {
 
-    fun getFullDateWithTime(date: Date): String = formatDate(date, "MMMM d, yyyy, hh:mm")
+    fun getOnlyTime(date: Date): String = formatDate(date, "HH:mm")
     fun getFullDateWithShortMonth(date: Date): String = formatDate(date, "MMM d, yyyy, HH:mm")
 
     fun getRelativeDateString(context: Context, date: Date): String {
@@ -25,6 +25,12 @@ object DateHelper {
             isThisYear(date) -> getFormattedDateWithoutYear(date)
             else -> getFormattedDateWithYear(date)
         }
+    }
+
+    fun getShortDateForTransaction(date: Date): String = if (isThisYear(date)) {
+        formatDate(date, "MMM d")
+    } else {
+        formatDate(date, "MM/dd/yyyy")
     }
 
     private fun formatDate(date: Date, outputFormat: String) =

--- a/app/src/main/res/layout/fragment_transactions.xml
+++ b/app/src/main/res/layout/fragment_transactions.xml
@@ -31,6 +31,9 @@
 
         <android.support.v7.widget.RecyclerView
             android:id="@+id/recyclerTags"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp"
+            android:clipToPadding="false"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             />

--- a/app/src/main/res/layout/view_holder_transaction.xml
+++ b/app/src/main/res/layout/view_holder_transaction.xml
@@ -9,29 +9,56 @@
     android:clickable="true"
     >
 
-    <ImageView
-        android:id="@+id/imgAvatar"
+    <TextView
+        android:id="@+id/txDate"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
         android:layout_marginStart="16dp"
-        android:layout_marginTop="8dp"
-        android:src="@drawable/avatar_placeholder"
-        app:layout_constraintBottom_toBottomOf="parent"
+        android:fontFamily="@font/noto_sans_bold"
+        android:textAllCaps="true"
+        android:textColor="?TransactionDateColor"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toTopOf="@+id/txTime"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed"
+        tools:text="Jun 3"
+        />
+
+    <TextView
+        android:id="@+id/txTime"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="6dp"
+        android:textColor="@color/grey"
+        android:textSize="14sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/txDate"
+        tools:text="12:30"
+        />
+
+    <ImageView
+        android:id="@+id/statusIcon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="4dp"
+        android:layout_marginTop="4dp"
+        app:layout_constraintLeft_toRightOf="@id/txTime"
+        app:layout_constraintTop_toTopOf="@+id/txTime"
         />
 
     <TextView
         android:id="@+id/txAmount"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="12dp"
+        android:layout_marginEnd="16dp"
         android:fontFamily="@font/noto_sans_bold"
         android:textColor="@color/green_crypto"
-        android:textSize="14sp"
+        android:textSize="20sp"
         app:layout_constraintBottom_toTopOf="@+id/txValueInFiat"
-        app:layout_constraintStart_toEndOf="@+id/imgAvatar"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_chainStyle="packed"
         tools:text="+ 0,006482 BTC"
@@ -41,38 +68,14 @@
         android:id="@+id/txValueInFiat"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="12dp"
-        android:layout_marginTop="4dp"
-        android:fontFamily="@font/noto_sans"
-        android:textColor="@color/grey"
-        android:textSize="14sp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/imgAvatar"
-        app:layout_constraintTop_toBottomOf="@+id/txAmount"
-        tools:text="$400"
-        />
-
-    <TextView
-        android:id="@+id/txDate"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
         android:layout_marginEnd="16dp"
         android:fontFamily="@font/noto_sans"
         android:textColor="@color/grey"
         android:textSize="14sp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@id/txAmount"
-        tools:text="3 June 2018"
-        />
-
-    <ImageView
-        android:id="@+id/statusIcon"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:src="@drawable/pending"
-        app:layout_constraintRight_toRightOf="@id/txDate"
-        app:layout_constraintTop_toTopOf="@+id/txValueInFiat"
+        app:layout_constraintTop_toBottomOf="@+id/txAmount"
+        tools:text="$400"
         />
 
     <View

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -23,6 +23,7 @@
     <attr name="HudIconTint" format="reference|color" />
     <attr name="HudBackground" format="reference|color" />
     <attr name="HudTextColor" format="reference|color" />
+    <attr name="TransactionDateColor" format="reference|color" />
     <attr name="TransactionDetailBackground" format="reference|color" />
     <attr name="TransactionTextBoxBackground" format="reference|color" />
     <attr name="TransactionDetailValueTextColor" format="reference|color" />
@@ -66,6 +67,7 @@
         <item name="HudIconTint">@color/steel_grey</item>
         <item name="HudBackground">@color/black_85</item>
         <item name="HudTextColor">@color/white</item>
+        <item name="TransactionDateColor">@color/steel_grey</item>
         <item name="TransactionDetailBackground">@color/grey_20</item>
         <item name="TransactionTextBoxBackground">@color/text_box_background_dark</item>
         <item name="TransactionDetailValueTextColor">@color/bars_color</item>
@@ -109,6 +111,7 @@
         <item name="HudIconTint">@color/dark</item>
         <item name="HudBackground">@color/bars_color_95</item>
         <item name="HudTextColor">@color/dark</item>
+        <item name="TransactionDateColor">@color/dark</item>
         <item name="TransactionDetailBackground">@color/white</item>
         <item name="TransactionTextBoxBackground">@color/text_box_background_light</item>
         <item name="TransactionDetailValueTextColor">@color/dark</item>


### PR DESCRIPTION
- Update design in Transactions cells
- Add padding to top tabs
- Fix crash when user resumes app with BottomTransactionInfo opened
Close #118 